### PR TITLE
fix(inline header functions): make header file function inline

### DIFF
--- a/include/vda5050_msgs/json_utils/action.hpp
+++ b/include/vda5050_msgs/json_utils/action.hpp
@@ -37,7 +37,7 @@ namespace msg {
 /// \param msg Reference to the messge object to serialize
 ///
 /// \throws std::runtime_error If failed to serialize blockingType
-void to_json(nlohmann::json& j, const Action& msg)
+inline void to_json(nlohmann::json& j, const Action& msg)
 {
   j["actionType"] = msg.action_type;
   j["actionId"] = msg.action_id;
@@ -72,7 +72,7 @@ void to_json(nlohmann::json& j, const Action& msg)
 /// \param msg Reference to the Action message to populate
 ///
 /// \throws std::runtime_error If failed to deserialize blockingType
-void from_json(const nlohmann::json& j, Action& msg)
+inline void from_json(const nlohmann::json& j, Action& msg)
 {
   msg.action_type = j.at("actionType").get<std::string>();
   msg.action_id = j.at("actionId").get<std::string>();

--- a/include/vda5050_msgs/json_utils/action_parameter.hpp
+++ b/include/vda5050_msgs/json_utils/action_parameter.hpp
@@ -34,7 +34,7 @@ namespace msg {
 ///
 /// \param j Reference to a JSON object to be populated
 /// \param msg Reference to the message object to serialize
-void to_json(nlohmann::json& j, const ActionParameter& msg)
+inline void to_json(nlohmann::json& j, const ActionParameter& msg)
 {
   j["key"] = msg.key;
   j["value"] = msg.value;
@@ -45,7 +45,7 @@ void to_json(nlohmann::json& j, const ActionParameter& msg)
 ///
 /// \param j Reference to the JSON object containing serialized ActionParameter data
 /// \param msg Reference to the ActionParameter message to populate
-void from_json(const nlohmann::json& j, ActionParameter& msg)
+inline void from_json(const nlohmann::json& j, ActionParameter& msg)
 {
   msg.key = j.at("key").get<std::string>();
   msg.value = j.at("value").get<ActionParameterValue>();

--- a/include/vda5050_msgs/json_utils/action_parameter_value.hpp
+++ b/include/vda5050_msgs/json_utils/action_parameter_value.hpp
@@ -36,7 +36,7 @@ namespace msg {
 /// \param msg Reference to the message object to serialize
 ///
 /// \throws std::runtime_error If failed to serialize type
-void to_json(nlohmann::json& j, const ActionParameterValue& msg)
+inline void to_json(nlohmann::json& j, const ActionParameterValue& msg)
 {
   if (
     msg.type == ActionParameterValue::TYPE_ARRAY ||
@@ -62,7 +62,7 @@ void to_json(nlohmann::json& j, const ActionParameterValue& msg)
 /// \param msg Reference to the ActionParameterValue message to populate
 ///
 /// \throws std::runtime_error If failed to deserialize type
-void from_json(const nlohmann::json& j, ActionParameterValue& msg)
+inline void from_json(const nlohmann::json& j, ActionParameterValue& msg)
 {
   auto type = j.at("type").get<uint8_t>();
   if (

--- a/include/vda5050_msgs/json_utils/action_state.hpp
+++ b/include/vda5050_msgs/json_utils/action_state.hpp
@@ -37,7 +37,7 @@ namespace msg {
 /// \param msg Reference to the message object to serialize
 ///
 /// \throws std::runtime_error If failed to serialize actionStatus
-void to_json(nlohmann::json& j, const ActionState& msg)
+inline void to_json(nlohmann::json& j, const ActionState& msg)
 {
   j["actionId"] = msg.action_id;
 
@@ -80,7 +80,7 @@ void to_json(nlohmann::json& j, const ActionState& msg)
 /// \param msg Reference to the message object to populate
 ///
 /// \throws std::runtime_error If failed to deserialize actionStatus
-void from_json(const nlohmann::json& j, ActionState& msg)
+inline void from_json(const nlohmann::json& j, ActionState& msg)
 {
   msg.action_id = j.at("actionId").get<std::string>();
 

--- a/include/vda5050_msgs/json_utils/agv_position.hpp
+++ b/include/vda5050_msgs/json_utils/agv_position.hpp
@@ -35,7 +35,7 @@ namespace msg {
 ///
 /// \param j Reference to the JSON object to be populated
 /// \param msg Reference to the message object to serialize
-void to_json(nlohmann::json& j, const AGVPosition& msg)
+inline void to_json(nlohmann::json& j, const AGVPosition& msg)
 {
   j["x"] = msg.x;
   j["y"] = msg.y;
@@ -65,7 +65,7 @@ void to_json(nlohmann::json& j, const AGVPosition& msg)
 ///
 /// \param j Reference to the JSON object containing serialized data
 /// \param msg Reference to the message object to populate
-void from_json(const nlohmann::json& j, AGVPosition& msg)
+inline void from_json(const nlohmann::json& j, AGVPosition& msg)
 {
   msg.x = j.at("x").get<double>();
   msg.y = j.at("y").get<double>();

--- a/include/vda5050_msgs/json_utils/battery_state.hpp
+++ b/include/vda5050_msgs/json_utils/battery_state.hpp
@@ -33,7 +33,7 @@ namespace msg {
 ///
 /// \param j Reference to the JSON object to be populated
 /// \param msg Reference to the message object to serialize
-void to_json(nlohmann::json& j, const BatteryState& msg)
+inline void to_json(nlohmann::json& j, const BatteryState& msg)
 {
   j["batteryCharge"] = msg.battery_charge;
   j["charging"] = msg.charging;
@@ -60,7 +60,7 @@ void to_json(nlohmann::json& j, const BatteryState& msg)
 ///
 /// \param j Reference to the JSON object containing serialized data
 /// \param msg Reference to the message object to populate
-void from_json(const nlohmann::json& j, BatteryState& msg)
+inline void from_json(const nlohmann::json& j, BatteryState& msg)
 {
   msg.battery_charge = j.at("batteryCharge").get<double>();
   msg.charging = j.at("charging").get<bool>();

--- a/include/vda5050_msgs/json_utils/bounding_box_reference.hpp
+++ b/include/vda5050_msgs/json_utils/bounding_box_reference.hpp
@@ -33,7 +33,7 @@ namespace msg {
 ///
 /// \param j Reference to the JSON object to be populated
 /// \param msg Reference to the message object to serialize
-void to_json(nlohmann::json& j, const BoundingBoxReference& msg)
+inline void to_json(nlohmann::json& j, const BoundingBoxReference& msg)
 {
   j["x"] = msg.x;
   j["y"] = msg.y;
@@ -51,7 +51,7 @@ void to_json(nlohmann::json& j, const BoundingBoxReference& msg)
 ///
 /// \param j Reference to the JSON object containing serialized data
 /// \param msg Reference to the message object to populate
-void from_json(const nlohmann::json& j, BoundingBoxReference& msg)
+inline void from_json(const nlohmann::json& j, BoundingBoxReference& msg)
 {
   msg.x = j.at("x").get<double>();
   msg.y = j.at("y").get<double>();

--- a/include/vda5050_msgs/json_utils/connection.hpp
+++ b/include/vda5050_msgs/json_utils/connection.hpp
@@ -38,7 +38,7 @@ namespace msg {
 /// \param msg Reference to the message object to serialize
 ///
 /// \throws std::runtime_error If failed to serialize connectionState
-void to_json(nlohmann::json& j, const Connection& msg)
+inline void to_json(nlohmann::json& j, const Connection& msg)
 {
   to_json(j, msg.header);
 
@@ -64,7 +64,7 @@ void to_json(nlohmann::json& j, const Connection& msg)
 /// \param msg Reference to the Connection message to populate
 ///
 /// \throws std::runtime_error If failed to deserialize connectionState
-void from_json(const nlohmann::json& j, Connection& msg)
+inline void from_json(const nlohmann::json& j, Connection& msg)
 {
   from_json(j, msg.header);
 

--- a/include/vda5050_msgs/json_utils/control_point.hpp
+++ b/include/vda5050_msgs/json_utils/control_point.hpp
@@ -33,7 +33,7 @@ namespace msg {
 ///
 /// \param j Reference to the JSON object to be populated
 /// \param msg Reference to the message object to serialize
-void to_json(nlohmann::json& j, const ControlPoint& msg)
+inline void to_json(nlohmann::json& j, const ControlPoint& msg)
 {
   j["x"] = msg.x;
   j["y"] = msg.y;
@@ -46,7 +46,7 @@ void to_json(nlohmann::json& j, const ControlPoint& msg)
 ///
 /// \param j Reference to the JSON object containing serialized data
 /// \param msg Reference to the message object to populate
-void from_json(const nlohmann::json& j, ControlPoint& msg)
+inline void from_json(const nlohmann::json& j, ControlPoint& msg)
 {
   msg.x = j.at("x").get<double>();
   msg.y = j.at("y").get<double>();

--- a/include/vda5050_msgs/json_utils/edge.hpp
+++ b/include/vda5050_msgs/json_utils/edge.hpp
@@ -38,7 +38,7 @@ namespace msg {
 /// \param msg Reference to the message object to serialize
 ///
 /// \throws std::runtime_error If failed to serialize orientationType
-void to_json(nlohmann::json& j, const Edge& msg)
+inline void to_json(nlohmann::json& j, const Edge& msg)
 {
   j["edgeId"] = msg.edge_id;
   j["sequenceId"] = msg.sequence_id;
@@ -117,7 +117,7 @@ void to_json(nlohmann::json& j, const Edge& msg)
 /// \param msg Reference to the message object to populate
 ///
 /// \throws std::runtime_error If failed to deserialize orientationType
-void from_json(const nlohmann::json& j, Edge& msg)
+inline void from_json(const nlohmann::json& j, Edge& msg)
 {
   msg.edge_id = j.at("edgeId").get<std::string>();
   msg.sequence_id = j.at("sequenceId").get<int32_t>();

--- a/include/vda5050_msgs/json_utils/edge_state.hpp
+++ b/include/vda5050_msgs/json_utils/edge_state.hpp
@@ -38,7 +38,7 @@ namespace msg {
 ///
 /// \param j Reference to the JSON object to be populated
 /// \param msg Reference to the message object to serialize
-void to_json(nlohmann::json& j, const EdgeState& msg)
+inline void to_json(nlohmann::json& j, const EdgeState& msg)
 {
   j["edgeId"] = msg.edge_id;
   j["sequenceId"] = msg.sequence_id;
@@ -61,7 +61,7 @@ void to_json(nlohmann::json& j, const EdgeState& msg)
 ///
 /// \param j Reference to the JSON object containing serialized data
 /// \param msg Reference to the message object to populate
-void from_json(const nlohmann::json& j, EdgeState& msg)
+inline void from_json(const nlohmann::json& j, EdgeState& msg)
 {
   msg.edge_id = j.at("edgeId").get<std::string>();
   msg.sequence_id = j.at("sequenceId").get<uint32_t>();

--- a/include/vda5050_msgs/json_utils/error.hpp
+++ b/include/vda5050_msgs/json_utils/error.hpp
@@ -39,7 +39,7 @@ namespace msg {
 /// \param msg Reference to the message object to serialize
 ///
 /// \throws std::runtime_error If failed to serialize errorLevel
-void to_json(nlohmann::json& j, const Error& msg)
+inline void to_json(nlohmann::json& j, const Error& msg)
 {
   j["errorType"] = msg.error_type;
 
@@ -73,7 +73,7 @@ void to_json(nlohmann::json& j, const Error& msg)
 /// \param msg Reference to the message object to populate
 ///
 /// \throws std::runtime_error If failed to deserialize errorLevel
-void from_json(const nlohmann::json& j, Error& msg)
+inline void from_json(const nlohmann::json& j, Error& msg)
 {
   msg.error_type = j.at("errorType").get<std::string>();
 

--- a/include/vda5050_msgs/json_utils/error_reference.hpp
+++ b/include/vda5050_msgs/json_utils/error_reference.hpp
@@ -35,7 +35,7 @@ namespace msg {
 ///
 /// \param j Reference to the JSON object to be populated
 /// \param msg Reference to the message object to serialize
-void to_json(nlohmann::json& j, const ErrorReference& msg)
+inline void to_json(nlohmann::json& j, const ErrorReference& msg)
 {
   j["referenceKey"] = msg.reference_key;
   j["referenceValue"] = msg.reference_value;
@@ -47,7 +47,7 @@ void to_json(nlohmann::json& j, const ErrorReference& msg)
 ///
 /// \param j Reference to the JSON object containing serialized data
 /// \param msg Reference to the message object to populate
-void from_json(const nlohmann::json& j, ErrorReference& msg)
+inline void from_json(const nlohmann::json& j, ErrorReference& msg)
 {
   msg.reference_key = j.at("referenceKey").get<std::string>();
   msg.reference_value = j.at("referenceValue").get<std::string>();

--- a/include/vda5050_msgs/json_utils/header.hpp
+++ b/include/vda5050_msgs/json_utils/header.hpp
@@ -40,7 +40,7 @@ constexpr const char* ISO8601_FORMAT = "%Y-%m-%dT%H:%M:%S";
 /// \param msg Reference to the message object to serialize
 ///
 /// \throws std::runtime_error If failed to serialize timestamp
-void to_json(nlohmann::json& j, const Header& msg)
+inline void to_json(nlohmann::json& j, const Header& msg)
 {
   using std::chrono::duration_cast;
   using std::chrono::milliseconds;
@@ -76,7 +76,7 @@ void to_json(nlohmann::json& j, const Header& msg)
 /// \param msg Reference to the Header message to populate
 ///
 /// \throws std::runtime_error If failed to deserialize timestamp
-void from_json(const nlohmann::json& j, Header& msg)
+inline void from_json(const nlohmann::json& j, Header& msg)
 {
   using std::chrono::duration_cast;
   using std::chrono::milliseconds;

--- a/include/vda5050_msgs/json_utils/info.hpp
+++ b/include/vda5050_msgs/json_utils/info.hpp
@@ -40,7 +40,7 @@ namespace msg {
 /// \param msg Reference to the message object to serialize
 ///
 /// \throws std::runtime_error If failed to serialize infoLevel
-void to_json(nlohmann::json& j, const Info& msg)
+inline void to_json(nlohmann::json& j, const Info& msg)
 {
   j["infoType"] = msg.info_type;
 
@@ -74,7 +74,7 @@ void to_json(nlohmann::json& j, const Info& msg)
 /// \param msg Reference to the message object to populate
 ///
 /// \throws std::runtime_error If failed to deserialize infoLevel
-void from_json(const nlohmann::json& j, Info& msg)
+inline void from_json(const nlohmann::json& j, Info& msg)
 {
   msg.info_type = j.at("infoType").get<std::string>();
 

--- a/include/vda5050_msgs/json_utils/info_reference.hpp
+++ b/include/vda5050_msgs/json_utils/info_reference.hpp
@@ -35,7 +35,7 @@ namespace msg {
 ///
 /// \param j Reference to the JSON object to be populated
 /// \param msg Reference to the message object to serialize
-void to_json(nlohmann::json& j, const InfoReference& msg)
+inline void to_json(nlohmann::json& j, const InfoReference& msg)
 {
   j["referenceKey"] = msg.reference_key;
   j["referenceValue"] = msg.reference_value;
@@ -47,7 +47,7 @@ void to_json(nlohmann::json& j, const InfoReference& msg)
 ///
 /// \param j Reference to the JSON object containing serialized data
 /// \param msg Reference to the message object to populate
-void from_json(const nlohmann::json& j, InfoReference& msg)
+inline void from_json(const nlohmann::json& j, InfoReference& msg)
 {
   msg.reference_key = j.at("referenceKey").get<std::string>();
   msg.reference_value = j.at("referenceValue").get<std::string>();

--- a/include/vda5050_msgs/json_utils/instant_actions.hpp
+++ b/include/vda5050_msgs/json_utils/instant_actions.hpp
@@ -36,7 +36,7 @@ namespace msg {
 ///
 /// \param j Reference to the JSON object to be populated
 /// \param msg Reference to the message object to serialize
-void to_json(nlohmann::json& j, const InstantActions& msg)
+inline void to_json(nlohmann::json& j, const InstantActions& msg)
 {
   to_json(j, msg.header);
 
@@ -48,7 +48,7 @@ void to_json(nlohmann::json& j, const InstantActions& msg)
 ///
 /// \param j Reference to the JSON object containing serialized InstantAction data
 /// \param msg Reference to the InstantAction object to be populated
-void from_json(const nlohmann::json& j, InstantActions& msg)
+inline void from_json(const nlohmann::json& j, InstantActions& msg)
 {
   from_json(j, msg.header);
 

--- a/include/vda5050_msgs/json_utils/load.hpp
+++ b/include/vda5050_msgs/json_utils/load.hpp
@@ -40,7 +40,7 @@ namespace msg {
 ///
 /// \param j Reference to the JSON object to be populated
 /// \param msg Reference to the message object to serialize
-void to_json(nlohmann::json& j, const Load& msg)
+inline void to_json(nlohmann::json& j, const Load& msg)
 {
   if (!msg.load_id.empty())
   {
@@ -79,7 +79,7 @@ void to_json(nlohmann::json& j, const Load& msg)
 ///
 /// \param j Reference to the JSON object containing serialized data
 /// \param msg Reference to the message object to populate
-void from_json(const nlohmann::json& j, Load& msg)
+inline void from_json(const nlohmann::json& j, Load& msg)
 {
   if (j.contains("loadId"))
   {

--- a/include/vda5050_msgs/json_utils/load_dimensions.hpp
+++ b/include/vda5050_msgs/json_utils/load_dimensions.hpp
@@ -33,7 +33,7 @@ namespace msg {
 ///
 /// \param j Reference to the JSON object to be populated
 /// \param msg Reference to the message object to serialize
-void to_json(nlohmann::json& j, const LoadDimensions& msg)
+inline void to_json(nlohmann::json& j, const LoadDimensions& msg)
 {
   j["length"] = msg.length;
   j["width"] = msg.width;
@@ -50,7 +50,7 @@ void to_json(nlohmann::json& j, const LoadDimensions& msg)
 ///
 /// \param j Reference to the JSON object containing serialized data
 /// \param msg Reference to the message object to populate
-void from_json(const nlohmann::json& j, LoadDimensions& msg)
+inline void from_json(const nlohmann::json& j, LoadDimensions& msg)
 {
   msg.length = j.at("length").get<double>();
   msg.width = j.at("width").get<double>();

--- a/include/vda5050_msgs/json_utils/node.hpp
+++ b/include/vda5050_msgs/json_utils/node.hpp
@@ -37,7 +37,7 @@ namespace msg {
 ///
 /// \param j Reference to the JSON object to be populated
 /// \param msg Reference to the message object to serialize
-void to_json(nlohmann::json& j, const Node& msg)
+inline void to_json(nlohmann::json& j, const Node& msg)
 {
   j["nodeId"] = msg.node_id;
   j["sequenceId"] = msg.sequence_id;
@@ -60,7 +60,7 @@ void to_json(nlohmann::json& j, const Node& msg)
 ///
 /// \param j Reference to the JSON object containing serialized data
 /// \param msg Reference to the message object to populate
-void from_json(const nlohmann::json& j, Node& msg)
+inline void from_json(const nlohmann::json& j, Node& msg)
 {
   msg.node_id = j.at("nodeId").get<std::string>();
   msg.sequence_id = j.at("sequenceId").get<uint32_t>();

--- a/include/vda5050_msgs/json_utils/node_position.hpp
+++ b/include/vda5050_msgs/json_utils/node_position.hpp
@@ -35,7 +35,7 @@ namespace msg {
 ///
 /// \param j Reference to the JSON object to be populated
 /// \param msg Reference to the message object to serialize
-void to_json(nlohmann::json& j, const NodePosition& msg)
+inline void to_json(nlohmann::json& j, const NodePosition& msg)
 {
   j["x"] = msg.x;
   j["y"] = msg.y;
@@ -68,7 +68,7 @@ void to_json(nlohmann::json& j, const NodePosition& msg)
 ///
 /// \param j Reference to the JSON object containing serialized data
 /// \param msg Reference to the message object to populate
-void from_json(const nlohmann::json& j, NodePosition& msg)
+inline void from_json(const nlohmann::json& j, NodePosition& msg)
 {
   msg.x = j.at("x").get<double>();
   msg.y = j.at("y").get<double>();

--- a/include/vda5050_msgs/json_utils/node_state.hpp
+++ b/include/vda5050_msgs/json_utils/node_state.hpp
@@ -38,7 +38,7 @@ namespace msg {
 ///
 /// \param j Reference to the JSON object to be populated
 /// \param msg Reference to the message object to serialize
-void to_json(nlohmann::json& j, const NodeState& msg)
+inline void to_json(nlohmann::json& j, const NodeState& msg)
 {
   j["nodeId"] = msg.node_id;
   j["sequenceId"] = msg.sequence_id;
@@ -61,7 +61,7 @@ void to_json(nlohmann::json& j, const NodeState& msg)
 ///
 /// \param j Reference to the JSON object containing serialized data
 /// \param msg Reference to the message object to populate
-void from_json(const nlohmann::json& j, NodeState& msg)
+inline void from_json(const nlohmann::json& j, NodeState& msg)
 {
   msg.node_id = j.at("nodeId").get<std::string>();
   msg.sequence_id = j.at("sequenceId").get<uint32_t>();

--- a/include/vda5050_msgs/json_utils/order.hpp
+++ b/include/vda5050_msgs/json_utils/order.hpp
@@ -38,7 +38,7 @@ namespace msg {
 ///
 /// \param j Reference to the JSON object to be populated
 /// \param msg Reference to the message object to serialize
-void to_json(nlohmann::json& j, const Order& msg)
+inline void to_json(nlohmann::json& j, const Order& msg)
 {
   to_json(j, msg.header);
 
@@ -58,7 +58,7 @@ void to_json(nlohmann::json& j, const Order& msg)
 ///
 /// \param j Reference to the JSON object containing serialized data
 /// \param msg Reference to the message object to populate
-void from_json(const nlohmann::json& j, Order& msg)
+inline void from_json(const nlohmann::json& j, Order& msg)
 {
   from_json(j, msg.header);
 

--- a/include/vda5050_msgs/json_utils/safety_state.hpp
+++ b/include/vda5050_msgs/json_utils/safety_state.hpp
@@ -37,7 +37,7 @@ namespace msg {
 /// \param msg Reference to the message object to serialize
 ///
 /// \throws std::runtime_error If failed to serialize eStop
-void to_json(nlohmann::json& j, const SafetyState& msg)
+inline void to_json(nlohmann::json& j, const SafetyState& msg)
 {
   if (
     msg.e_stop == SafetyState::E_STOP_AUTOACK ||
@@ -63,7 +63,7 @@ void to_json(nlohmann::json& j, const SafetyState& msg)
 /// \param msg Reference to the message object to populate
 ///
 /// \throws std::runtime_error If failed to deserialize eStop
-void from_json(const nlohmann::json& j, SafetyState& msg)
+inline void from_json(const nlohmann::json& j, SafetyState& msg)
 {
   auto e_stop = j.at("eStop").get<std::string>();
   if (

--- a/include/vda5050_msgs/json_utils/state.hpp
+++ b/include/vda5050_msgs/json_utils/state.hpp
@@ -58,7 +58,7 @@ namespace msg {
 /// \param msg Reference to the message object to serialize
 ///
 /// \throws std::runtime_error If failed to serialize operatingMode
-void to_json(nlohmann::json& j, const State& msg)
+inline void to_json(nlohmann::json& j, const State& msg)
 {
   to_json(j, msg.header);
 
@@ -138,7 +138,7 @@ void to_json(nlohmann::json& j, const State& msg)
 /// \param msg Reference to the message object to populate
 ///
 /// \throws std::runtime_error If failed to deserialize operatingMode
-void from_json(const nlohmann::json& j, State& msg)
+inline void from_json(const nlohmann::json& j, State& msg)
 {
   from_json(j, msg.header);
 

--- a/include/vda5050_msgs/json_utils/trajectory.hpp
+++ b/include/vda5050_msgs/json_utils/trajectory.hpp
@@ -38,7 +38,7 @@ namespace msg {
 ///
 /// \param j Reference to the JSON object to be populated
 /// \param msg Reference to the message object to serialize
-void to_json(nlohmann::json& j, const Trajectory& msg)
+inline void to_json(nlohmann::json& j, const Trajectory& msg)
 {
   j["knotVector"] = msg.knot_vector;
   j["controlPoints"] = msg.control_points;
@@ -51,7 +51,7 @@ void to_json(nlohmann::json& j, const Trajectory& msg)
 ///
 /// \param j Reference to the JSON object containing serialized data
 /// \param msg Reference to the message object to populate
-void from_json(const nlohmann::json& j, Trajectory& msg)
+inline void from_json(const nlohmann::json& j, Trajectory& msg)
 {
   msg.knot_vector = j.at("knotVector").get<std::vector<double>>();
   msg.control_points = j.at("controlPoints").get<std::vector<ControlPoint>>();

--- a/include/vda5050_msgs/json_utils/velocity.hpp
+++ b/include/vda5050_msgs/json_utils/velocity.hpp
@@ -33,7 +33,7 @@ namespace msg {
 ///
 /// \param j Reference to the JSON object to be populated
 /// \param msg Reference to the message object to serialize
-void to_json(nlohmann::json& j, const Velocity& msg)
+inline void to_json(nlohmann::json& j, const Velocity& msg)
 {
   if (!msg.vx.empty())
   {
@@ -57,7 +57,7 @@ void to_json(nlohmann::json& j, const Velocity& msg)
 ///
 /// \param j Reference to the JSON object containing serialized data
 /// \param msg Reference to the message object to populate
-void from_json(const nlohmann::json& j, Velocity& msg)
+inline void from_json(const nlohmann::json& j, Velocity& msg)
 {
   if (j.contains("vx"))
   {

--- a/include/vda5050_msgs/json_utils/visualization.hpp
+++ b/include/vda5050_msgs/json_utils/visualization.hpp
@@ -37,7 +37,7 @@ namespace msg {
 ///
 /// \param j Reference to the JSON object to be populated
 /// \param msg Reference to the message object to serialize
-void to_json(nlohmann::json& j, const Visualization& msg)
+inline void to_json(nlohmann::json& j, const Visualization& msg)
 {
   to_json(j, msg.header);
 
@@ -58,7 +58,7 @@ void to_json(nlohmann::json& j, const Visualization& msg)
 ///
 /// \param j Reference to the JSON object containing serialized data
 /// \param msg Reference to the message object to populate
-void from_json(const nlohmann::json& j, Visualization& msg)
+inline void from_json(const nlohmann::json& j, Visualization& msg)
 {
   from_json(j, msg.header);
 


### PR DESCRIPTION
Raising this PR to  address issue https://github.com/ros-industrial/vda5050_interfaces/issues/13. All header files functions are now declared as `inline` to enable the header file to be included more than once.